### PR TITLE
fix: convert AvailableVersion to string for proper display

### DIFF
--- a/functions/Get-Updates.ps1
+++ b/functions/Get-Updates.ps1
@@ -48,7 +48,7 @@ function Get-Updates {
 					[PSCustomObject]@{
 						Module           = $Module.Name
 						CurrentVersion   = $Module.Version.ToString()
-						AvailableVersion = $Available.Version
+						AvailableVersion = $Available.Version.ToString()
 					}
 				}
 			} catch {
@@ -63,7 +63,7 @@ function Get-Updates {
 					[PSCustomObject]@{
 						Module           = $Module.Name
 						CurrentVersion   = $Module.Version.ToString()
-						AvailableVersion = $Available.Version
+						AvailableVersion = $Available.Version.ToString()
 					}
 				}
 			} catch {


### PR DESCRIPTION
### **User description**
## Summary

- Fixes the AvailableVersion column displaying as a hashtable instead of a version string
- Adds `.ToString()` to `$Available.Version` in both PS7+ parallel and legacy code paths

## Problem

When displaying PowerShell module updates, the `AvailableVersion` column showed:
```
@{Major=15; Minor=2; Build=0; Revision=-1; MajorRevision=-1; MinorRevision=-1}
```
instead of `15.2.0`.

## Root Cause

The `Version` object from `Find-Module` was stored directly. After JSON serialization/deserialization, it lost its type information and displayed as a hashtable.

## Fix

Convert to string before storing (matching `CurrentVersion` behavior):
```powershell
AvailableVersion = $Available.Version.ToString()
```

Fixes #57


___

### **PR Type**
Bug fix


___

### **Description**
- Convert AvailableVersion to string

- Add .ToString() in parallel code branch

- Add .ToString() in legacy code branch


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Get-Updates.ps1</strong><dd><code>Convert AvailableVersion to string</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

functions/Get-Updates.ps1

<ul><li>Added <code>.ToString()</code> for AvailableVersion in parallel path<br> <li> Added <code>.ToString()</code> for AvailableVersion in legacy path</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/PSF-Module/pull/58/files#diff-12b2cdb22d137512b4e21db55fe35908a4138f1b9ae1b6da92c8db80508dd2fc">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

